### PR TITLE
Add browser Call Control dialer sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ yarn install
    - [Alibaba Qwen realtime](./examples/alibaba-qwen-realtime/README.md) — DashScope Qwen Omni Realtime
    - [xAI Grok realtime](./examples/xai-realtime/README.md) — xAI Grok Voice Agent
    - [Gemini Live realtime](./examples/gemini-realtime/README.md) — Gemini Live API
+   - [Web Dialer](./examples/web-dialer/README.md) — browser microphone and speaker calling without SIP registration
 
 3. When ready, start from the repo root:
 
@@ -57,6 +58,7 @@ yarn start:openai            # OpenAI Realtime API
 yarn start:alibaba-qwen      # Alibaba Qwen Omni Realtime
 yarn start:xai               # xAI Grok Voice Agent
 yarn start:gemini            # Gemini Live realtime
+yarn start:web-dialer        # Browser dialer (no SIP registration)
 ```
 
 ## License

--- a/examples/web-dialer/README.md
+++ b/examples/web-dialer/README.md
@@ -5,7 +5,7 @@ A TypeScript browser dialer that uses a 3CX programmable DN (RoutePoint) through
 ## Features
 
 - Browser keypad with outbound calling
-- Incoming calls routed to the API application's Client ID or assigned DID
+- Incoming-call screen with local ringtone, accept, reject, and a 30-second timeout
 - Microphone and speaker bridge using 3CX 8 kHz, 16-bit mono PCM streams
 - Mute, hang up, call timer, and recent-call history
 - Credentials are sent once to the local Node process and are never written to browser storage
@@ -42,4 +42,6 @@ The browser sends microphone PCM over a same-origin WebSocket to the local Node 
 
 This is a development sample, not a production softphone. For remote deployment, add HTTPS, user authentication, authorization, rate limiting, origin validation, secure secret storage, and an explicit session policy. The sample supports one active call per browser session.
 
-RoutePoint calls normally arrive already connected. This makes the sample suitable for programmable voice apps but differs from the ringing/answer lifecycle of a conventional registered extension.
+RoutePoint calls normally arrive already connected at the PBX. The incoming-call screen therefore implements a **local virtual ringing phase**: media is withheld until the user presses Accept, but the underlying RoutePoint leg is technically already connected. This differs from the real SIP ringing/answer lifecycle of a conventional registered extension.
+
+To keep conversational latency bounded, the browser captures approximately 20 ms at a time and both sides drop stale audio when their real-time buffers exceed a small limit. Hanging up synchronously clears microphone upload, PBX writer, and browser playback queues.

--- a/examples/web-dialer/README.md
+++ b/examples/web-dialer/README.md
@@ -1,0 +1,45 @@
+# 3CX Web Dialer
+
+A TypeScript browser dialer that uses a 3CX programmable DN (RoutePoint) through the Call Control API. It makes and receives calls without registering a SIP endpoint.
+
+## Features
+
+- Browser keypad with outbound calling
+- Incoming calls routed to the API application's Client ID or assigned DID
+- Microphone and speaker bridge using 3CX 8 kHz, 16-bit mono PCM streams
+- Mute, hang up, call timer, and recent-call history
+- Credentials are sent once to the local Node process and are never written to browser storage
+
+## 3CX setup
+
+1. In the 3CX Admin Console, create an API Integration / Voice App.
+2. Set a Client ID; it is also the programmable DN used by this app.
+3. Enable Call Control API access and save the generated key.
+4. Assign a DID to the application if inbound external calls are required.
+
+The app's own DN must be a RoutePoint. Audio streaming is not available for ordinary monitored extension DNs.
+
+## Run
+
+From the repository root:
+
+```bash
+yarn install
+yarn workspace @3cx-examples/web-dialer start
+```
+
+Open <http://localhost:8787>, enter the PBX URL, Client ID, and Key, then allow microphone access.
+
+The server listens on localhost by default. Set `PORT` to change the port:
+
+```bash
+PORT=9000 yarn workspace @3cx-examples/web-dialer start
+```
+
+## Architecture and security
+
+The browser sends microphone PCM over a same-origin WebSocket to the local Node gateway. The gateway owns the authenticated 3CX SDK connection and bridges PCM in both directions. Call history is stored only in the browser's `localStorage`.
+
+This is a development sample, not a production softphone. For remote deployment, add HTTPS, user authentication, authorization, rate limiting, origin validation, secure secret storage, and an explicit session policy. The sample supports one active call per browser session.
+
+RoutePoint calls normally arrive already connected. This makes the sample suitable for programmable voice apps but differs from the ringing/answer lifecycle of a conventional registered extension.

--- a/examples/web-dialer/package.json
+++ b/examples/web-dialer/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@3cx-examples/web-dialer",
+  "version": "1.0.0",
+  "license": "MIT",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.web.json",
+    "start": "yarn build && tsx src/server.ts",
+    "dev": "tsx watch src/server.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@3cx/call-control-sdk": "^0.1.10",
+    "tsx": "^4.21.0",
+    "ws": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/web-dialer/src/server.ts
+++ b/examples/web-dialer/src/server.ts
@@ -1,0 +1,256 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+import type { Readable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+
+import { CallControlClient, type Participant } from '@3cx/call-control-sdk';
+import { WebSocket, WebSocketServer } from 'ws';
+
+interface ConnectMessage {
+    type: 'connect';
+    pbxBase: string;
+    appId: string;
+    appSecret: string;
+}
+
+interface DialMessage {
+    type: 'dial';
+    destination: string;
+}
+
+interface HangupMessage {
+    type: 'hangup';
+}
+
+type ClientMessage = ConnectMessage | DialMessage | HangupMessage;
+
+const port = Number(process.env.PORT ?? 8787);
+const webRoot = fileURLToPath(new URL('../web', import.meta.url));
+const builtWebRoot = fileURLToPath(new URL('../dist/web', import.meta.url));
+
+const mimeTypes: Record<string, string> = {
+    '.css': 'text/css; charset=utf-8',
+    '.html': 'text/html; charset=utf-8',
+    '.js': 'text/javascript; charset=utf-8',
+    '.svg': 'image/svg+xml',
+};
+
+function serveStatic(req: IncomingMessage, res: ServerResponse): void {
+    const pathname = new URL(req.url ?? '/', 'http://localhost').pathname;
+    const requested = pathname === '/' ? 'index.html' : pathname.slice(1);
+    const safePath = normalize(requested).replace(/^(\.\.(\/|\\|$))+/, '');
+    let filePath = safePath === 'app.js' ? join(builtWebRoot, safePath) : join(webRoot, safePath);
+    if (!existsSync(filePath) || statSync(filePath).isDirectory()) filePath = join(webRoot, 'index.html');
+
+    res.writeHead(200, {
+        'Content-Type': mimeTypes[extname(filePath)] ?? 'application/octet-stream',
+        'Cache-Control': 'no-store',
+        'X-Content-Type-Options': 'nosniff',
+        'Referrer-Policy': 'no-referrer',
+    });
+    createReadStream(filePath).pipe(res);
+}
+
+const server = createServer(serveStatic);
+const wss = new WebSocketServer({ server, path: '/ws', maxPayload: 64 * 1024 });
+
+function messageOf(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function normalizePbxBase(value: string): string {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'https:') throw new Error('3CX 域名必须使用 https://');
+    url.pathname = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString().replace(/\/$/, '');
+}
+
+class DialerSession {
+    private client: CallControlClient | null = null;
+    private activeParticipant: Participant | null = null;
+    private audioStream: Readable | null = null;
+    private pendingDestination = '';
+    private pendingParticipantId: number | null = null;
+    private cancelPendingCall = false;
+    private callDirection: 'incoming' | 'outgoing' = 'incoming';
+
+    constructor(private readonly socket: WebSocket) {}
+
+    private send(payload: Record<string, unknown>): void {
+        if (this.socket.readyState === WebSocket.OPEN) this.socket.send(JSON.stringify(payload));
+    }
+
+    fail(error: unknown): void {
+        this.send({ type: 'error', message: messageOf(error) });
+    }
+
+    async handleText(text: string): Promise<void> {
+        let message: ClientMessage;
+        try {
+            message = JSON.parse(text) as ClientMessage;
+        } catch {
+            throw new Error('无效的客户端消息');
+        }
+
+        if (message.type === 'connect') await this.connect(message);
+        else if (message.type === 'dial') await this.dial(message.destination);
+        else if (message.type === 'hangup') await this.hangup();
+        else throw new Error('不支持的操作');
+    }
+
+    handleAudio(data: Buffer): void {
+        if (!this.activeParticipant || data.length === 0) return;
+        this.activeParticipant.getAudioWriter().write(data);
+    }
+
+    private async connect(message: ConnectMessage): Promise<void> {
+        if (this.client) throw new Error('已经连接到 3CX，请先刷新页面再更换账号');
+        const appId = message.appId.trim();
+        const appSecret = message.appSecret.trim();
+        if (!appId || !appSecret) throw new Error('Client ID 和 Key 不能为空');
+
+        const client = new CallControlClient({
+            pbxBase: normalizePbxBase(message.pbxBase),
+            appId,
+            appSecret,
+        });
+
+        client.on('participantConnected', (participant) => void this.onParticipantConnected(participant));
+        client.on('participantDisconnected', (id) => this.onParticipantDisconnected(id));
+        client.on('error', (error) => this.fail(error));
+        client.on('disconnected', () => this.send({ type: 'pbx-state', state: 'disconnected' }));
+
+        await client.connect();
+        this.client = client;
+        this.send({ type: 'pbx-state', state: 'connected', appId });
+    }
+
+    private async dial(destinationValue: string): Promise<void> {
+        if (!this.client) throw new Error('请先连接 3CX');
+        if (this.activeParticipant || this.pendingDestination) throw new Error('当前已有通话');
+        const destination = destinationValue.trim();
+        if (!/^[0-9+*#]+$/.test(destination)) throw new Error('号码只能包含数字、+、* 和 #');
+
+        this.pendingDestination = destination;
+        this.cancelPendingCall = false;
+        this.callDirection = 'outgoing';
+        this.send({ type: 'call-state', state: 'dialing', party: destination, direction: 'outgoing' });
+        try {
+            const participantId = await this.client.makeCall(destination);
+            this.pendingParticipantId = participantId ?? null;
+            if (this.cancelPendingCall && participantId != null) {
+                await this.client.drop(participantId).catch(() => undefined);
+                this.pendingParticipantId = null;
+                this.cancelPendingCall = false;
+            }
+        } catch (error) {
+            this.pendingDestination = '';
+            this.pendingParticipantId = null;
+            this.cancelPendingCall = false;
+            this.send({ type: 'call-state', state: 'idle' });
+            throw error;
+        }
+    }
+
+    private async onParticipantConnected(participant: Participant): Promise<void> {
+        if (this.cancelPendingCall) {
+            this.pendingParticipantId = participant.id;
+            await participant.drop().catch(() => undefined);
+            return;
+        }
+        if (this.activeParticipant && this.activeParticipant.id !== participant.id) {
+            await participant.drop().catch(() => undefined);
+            return;
+        }
+
+        this.activeParticipant = participant;
+        const party = this.pendingDestination
+            || participant.info.party_caller_name
+            || participant.info.party_caller_id
+            || participant.info.party_dn
+            || '未知号码';
+        const direction = this.pendingDestination ? 'outgoing' : 'incoming';
+        this.callDirection = direction;
+        this.pendingDestination = '';
+        this.pendingParticipantId = null;
+        this.cancelPendingCall = false;
+        this.send({
+            type: 'call-state',
+            state: 'connected',
+            participantId: participant.id,
+            party,
+            direction,
+        });
+
+        try {
+            const stream = await participant.getAudioStream();
+            if (this.activeParticipant?.id !== participant.id) {
+                stream.destroy();
+                return;
+            }
+            this.audioStream = stream;
+            stream.on('data', (chunk: Buffer) => {
+                if (this.socket.readyState === WebSocket.OPEN) this.socket.send(chunk, { binary: true });
+            });
+            stream.on('error', (error) => this.fail(error));
+        } catch (error) {
+            this.fail(error);
+        }
+    }
+
+    private onParticipantDisconnected(id: number): void {
+        if (this.activeParticipant?.id !== id) return;
+        this.stopAudio();
+        this.activeParticipant = null;
+        this.pendingDestination = '';
+        this.pendingParticipantId = null;
+        this.cancelPendingCall = false;
+        this.send({ type: 'call-state', state: 'ended', direction: this.callDirection });
+    }
+
+    private async hangup(): Promise<void> {
+        if (this.activeParticipant) {
+            await this.activeParticipant.drop();
+            return;
+        }
+        if (this.pendingDestination) {
+            this.cancelPendingCall = true;
+            if (this.pendingParticipantId != null && this.client) {
+                await this.client.drop(this.pendingParticipantId).catch(() => undefined);
+                this.pendingParticipantId = null;
+                this.cancelPendingCall = false;
+            }
+            this.pendingDestination = '';
+            this.send({ type: 'call-state', state: 'idle' });
+        }
+    }
+
+    private stopAudio(): void {
+        this.audioStream?.destroy();
+        this.audioStream = null;
+    }
+
+    close(): void {
+        this.stopAudio();
+        this.client?.disconnect();
+        this.client = null;
+        this.activeParticipant = null;
+    }
+}
+
+wss.on('connection', (socket) => {
+    const session = new DialerSession(socket);
+    socket.on('message', (data, isBinary) => {
+        if (isBinary) session.handleAudio(Buffer.from(data as Buffer));
+        else void session.handleText(data.toString()).catch((error) => session.fail(error));
+    });
+    socket.on('close', () => session.close());
+    socket.on('error', () => session.close());
+});
+
+server.listen(port, '127.0.0.1', () => {
+    console.log(`3CX Web Dialer: http://localhost:${port}`);
+});

--- a/examples/web-dialer/src/server.ts
+++ b/examples/web-dialer/src/server.ts
@@ -4,7 +4,7 @@ import { extname, join, normalize } from 'node:path';
 import type { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
-import { CallControlClient, type Participant } from '@3cx/call-control-sdk';
+import { CallControlClient, type AudioWriter, type Participant } from '@3cx/call-control-sdk';
 import { WebSocket, WebSocketServer } from 'ws';
 
 interface ConnectMessage {
@@ -23,9 +23,33 @@ interface HangupMessage {
     type: 'hangup';
 }
 
-type ClientMessage = ConnectMessage | DialMessage | HangupMessage;
+interface AcceptMessage {
+    type: 'accept';
+}
+
+type ClientMessage = ConnectMessage | DialMessage | HangupMessage | AcceptMessage;
 
 const port = Number(process.env.PORT ?? 8787);
+const maxBufferedAudioBytes = 320 * 10;
+const maxSocketBufferedBytes = 64 * 1024;
+const incomingRingTimeoutMs = 30_000;
+const ringbackCycleMs = 3_000;
+
+function createRingbackTone(): Buffer {
+    const sampleRate = 8_000;
+    const durationSeconds = 1;
+    const samples = sampleRate * durationSeconds;
+    const pcm = Buffer.alloc(samples * 2);
+    for (let index = 0; index < samples; index++) {
+        const time = index / sampleRate;
+        const fade = Math.min(1, index / 80, (samples - index) / 80);
+        const mixed = (Math.sin(2 * Math.PI * 440 * time) + Math.sin(2 * Math.PI * 480 * time)) * 0.12 * fade;
+        pcm.writeInt16LE(Math.round(mixed * 0x7fff), index * 2);
+    }
+    return pcm;
+}
+
+const ringbackTone = createRingbackTone();
 const webRoot = fileURLToPath(new URL('../web', import.meta.url));
 const builtWebRoot = fileURLToPath(new URL('../dist/web', import.meta.url));
 
@@ -72,6 +96,11 @@ class DialerSession {
     private client: CallControlClient | null = null;
     private activeParticipant: Participant | null = null;
     private audioStream: Readable | null = null;
+    private audioWriter: AudioWriter | null = null;
+    private mediaActive = false;
+    private incomingParty = '';
+    private ringTimer: NodeJS.Timeout | null = null;
+    private ringbackTimer: NodeJS.Timeout | null = null;
     private pendingDestination = '';
     private pendingParticipantId: number | null = null;
     private cancelPendingCall = false;
@@ -97,13 +126,16 @@ class DialerSession {
 
         if (message.type === 'connect') await this.connect(message);
         else if (message.type === 'dial') await this.dial(message.destination);
+        else if (message.type === 'accept') await this.accept();
         else if (message.type === 'hangup') await this.hangup();
         else throw new Error('不支持的操作');
     }
 
     handleAudio(data: Buffer): void {
-        if (!this.activeParticipant || data.length === 0) return;
-        this.activeParticipant.getAudioWriter().write(data);
+        if (!this.activeParticipant || !this.mediaActive || data.length === 0) return;
+        this.audioWriter ??= this.activeParticipant.getAudioWriter();
+        if (this.audioWriter.bufferedBytes > maxBufferedAudioBytes) this.audioWriter.clear();
+        this.audioWriter.write(data);
     }
 
     private async connect(message: ConnectMessage): Promise<void> {
@@ -177,6 +209,36 @@ class DialerSession {
         this.pendingDestination = '';
         this.pendingParticipantId = null;
         this.cancelPendingCall = false;
+        if (direction === 'incoming') {
+            this.incomingParty = party;
+            this.send({
+                type: 'call-state',
+                state: 'ringing',
+                participantId: participant.id,
+                party,
+                direction,
+            });
+            this.startRemoteRingback(participant);
+            this.ringTimer = setTimeout(() => void this.hangup(), incomingRingTimeoutMs);
+            return;
+        }
+
+        await this.startMedia(participant, party, direction);
+    }
+
+    private async accept(): Promise<void> {
+        if (!this.activeParticipant || this.callDirection !== 'incoming' || this.mediaActive) return;
+        this.clearRingTimer();
+        this.stopRemoteRingback();
+        await this.startMedia(this.activeParticipant, this.incomingParty || '未知号码', 'incoming');
+    }
+
+    private async startMedia(
+        participant: Participant,
+        party: string,
+        direction: 'incoming' | 'outgoing',
+    ): Promise<void> {
+        this.mediaActive = true;
         this.send({
             type: 'call-state',
             state: 'connected',
@@ -187,13 +249,19 @@ class DialerSession {
 
         try {
             const stream = await participant.getAudioStream();
-            if (this.activeParticipant?.id !== participant.id) {
+            if (this.activeParticipant?.id !== participant.id || !this.mediaActive) {
                 stream.destroy();
                 return;
             }
             this.audioStream = stream;
             stream.on('data', (chunk: Buffer) => {
-                if (this.socket.readyState === WebSocket.OPEN) this.socket.send(chunk, { binary: true });
+                if (
+                    this.mediaActive
+                    && this.socket.readyState === WebSocket.OPEN
+                    && this.socket.bufferedAmount < maxSocketBufferedBytes
+                ) {
+                    this.socket.send(chunk, { binary: true });
+                }
             });
             stream.on('error', (error) => this.fail(error));
         } catch (error) {
@@ -204,7 +272,10 @@ class DialerSession {
     private onParticipantDisconnected(id: number): void {
         if (this.activeParticipant?.id !== id) return;
         this.stopAudio();
+        this.clearRingTimer();
+        this.stopRemoteRingback();
         this.activeParticipant = null;
+        this.incomingParty = '';
         this.pendingDestination = '';
         this.pendingParticipantId = null;
         this.cancelPendingCall = false;
@@ -213,7 +284,12 @@ class DialerSession {
 
     private async hangup(): Promise<void> {
         if (this.activeParticipant) {
-            await this.activeParticipant.drop();
+            const participant = this.activeParticipant;
+            this.clearRingTimer();
+            this.stopRemoteRingback();
+            this.stopAudio();
+            this.send({ type: 'call-state', state: 'ended', direction: this.callDirection });
+            await participant.drop().catch((error) => this.fail(error));
             return;
         }
         if (this.pendingDestination) {
@@ -229,12 +305,37 @@ class DialerSession {
     }
 
     private stopAudio(): void {
+        this.mediaActive = false;
         this.audioStream?.destroy();
         this.audioStream = null;
+        this.audioWriter?.clear();
+        this.audioWriter?.cancel();
+        this.audioWriter = null;
+    }
+
+    private startRemoteRingback(participant: Participant): void {
+        this.stopRemoteRingback();
+        this.audioWriter = participant.getAudioWriter();
+        const writeTone = () => this.audioWriter?.write(ringbackTone);
+        writeTone();
+        this.ringbackTimer = setInterval(writeTone, ringbackCycleMs);
+    }
+
+    private stopRemoteRingback(): void {
+        if (this.ringbackTimer) clearInterval(this.ringbackTimer);
+        this.ringbackTimer = null;
+        this.audioWriter?.clear();
+    }
+
+    private clearRingTimer(): void {
+        if (this.ringTimer) clearTimeout(this.ringTimer);
+        this.ringTimer = null;
     }
 
     close(): void {
         this.stopAudio();
+        this.clearRingTimer();
+        this.stopRemoteRingback();
         this.client?.disconnect();
         this.client = null;
         this.activeParticipant = null;

--- a/examples/web-dialer/tsconfig.json
+++ b/examples/web-dialer/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"]
+  },
+  "include": ["src/**/*.ts", "web/**/*.ts"]
+}

--- a/examples/web-dialer/tsconfig.web.json
+++ b/examples/web-dialer/tsconfig.web.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": false,
+    "outDir": "dist/web",
+    "types": []
+  },
+  "include": ["web/app.ts"]
+}

--- a/examples/web-dialer/web/app.ts
+++ b/examples/web-dialer/web/app.ts
@@ -1,0 +1,291 @@
+interface ServerMessage {
+    type: 'pbx-state' | 'call-state' | 'error';
+    state?: 'connected' | 'disconnected' | 'dialing' | 'connected' | 'ended' | 'idle';
+    message?: string;
+    party?: string;
+    direction?: 'incoming' | 'outgoing';
+}
+
+interface HistoryEntry {
+    id: string;
+    party: string;
+    direction: 'incoming' | 'outgoing';
+    startedAt: number;
+    endedAt?: number;
+    answered: boolean;
+}
+
+const $ = <T extends HTMLElement>(selector: string) => document.querySelector<T>(selector)!;
+const setupPanel = $('#setupPanel');
+const phonePanel = $('#phonePanel');
+const connectionBadge = $('#connectionBadge');
+const connectForm = $('#connectForm') as HTMLFormElement;
+const connectButton = $('#connectButton') as HTMLButtonElement;
+const numberInput = $('#numberInput') as HTMLInputElement;
+const callButton = $('#callButton') as HTMLButtonElement;
+const hangupButton = $('#hangupButton') as HTMLButtonElement;
+const backspaceButton = $('#backspaceButton') as HTMLButtonElement;
+const muteButton = $('#muteButton') as HTMLButtonElement;
+const callLabel = $('#callLabel');
+const callTimer = $('#callTimer');
+const historyList = $('#historyList');
+const toast = $('#toast');
+
+let socket: WebSocket | null = null;
+let audioContext: AudioContext | null = null;
+let mediaStream: MediaStream | null = null;
+let micProcessor: ScriptProcessorNode | null = null;
+let muted = false;
+let callActive = false;
+let callStartedAt = 0;
+let timerId: number | null = null;
+let playbackTime = 0;
+let currentHistory: HistoryEntry | null = null;
+
+function showError(message: string): void {
+    toast.textContent = message;
+    toast.classList.remove('hidden');
+    window.setTimeout(() => toast.classList.add('hidden'), 5000);
+}
+
+function send(payload: Record<string, unknown>): void {
+    if (socket?.readyState !== WebSocket.OPEN) throw new Error('尚未连接本地服务');
+    socket.send(JSON.stringify(payload));
+}
+
+async function prepareAudio(): Promise<void> {
+    if (audioContext && mediaStream) {
+        await audioContext.resume();
+        return;
+    }
+
+    mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    });
+    audioContext = new AudioContext();
+    const source = audioContext.createMediaStreamSource(mediaStream);
+    micProcessor = audioContext.createScriptProcessor(4096, 1, 1);
+    const silentGain = audioContext.createGain();
+    silentGain.gain.value = 0;
+    source.connect(micProcessor);
+    micProcessor.connect(silentGain);
+    silentGain.connect(audioContext.destination);
+
+    micProcessor.onaudioprocess = (event) => {
+        if (!callActive || muted || socket?.readyState !== WebSocket.OPEN || !audioContext) return;
+        const input = event.inputBuffer.getChannelData(0);
+        socket.send(floatToPcm16(downsample(input, audioContext.sampleRate, 8000)));
+    };
+}
+
+function downsample(input: Float32Array, inputRate: number, outputRate: number): Float32Array {
+    if (inputRate === outputRate) return input;
+    const ratio = inputRate / outputRate;
+    const outputLength = Math.floor(input.length / ratio);
+    const output = new Float32Array(outputLength);
+    for (let i = 0; i < outputLength; i++) {
+        const start = Math.floor(i * ratio);
+        const end = Math.min(Math.floor((i + 1) * ratio), input.length);
+        let sum = 0;
+        for (let j = start; j < end; j++) sum += input[j];
+        output[i] = sum / Math.max(1, end - start);
+    }
+    return output;
+}
+
+function floatToPcm16(input: Float32Array): ArrayBuffer {
+    const buffer = new ArrayBuffer(input.length * 2);
+    const view = new DataView(buffer);
+    for (let i = 0; i < input.length; i++) {
+        const sample = Math.max(-1, Math.min(1, input[i]));
+        view.setInt16(i * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+    }
+    return buffer;
+}
+
+function playPcm(data: ArrayBuffer): void {
+    if (!audioContext || !callActive || data.byteLength < 2) return;
+    const view = new DataView(data);
+    const samples = new Float32Array(Math.floor(data.byteLength / 2));
+    for (let i = 0; i < samples.length; i++) samples[i] = view.getInt16(i * 2, true) / 0x8000;
+    const buffer = audioContext.createBuffer(1, samples.length, 8000);
+    buffer.copyToChannel(samples, 0);
+    const source = audioContext.createBufferSource();
+    source.buffer = buffer;
+    source.connect(audioContext.destination);
+    const now = audioContext.currentTime;
+    playbackTime = Math.max(playbackTime, now + 0.04);
+    source.start(playbackTime);
+    playbackTime += buffer.duration;
+}
+
+function connectSocket(): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+        socket = new WebSocket(`${protocol}//${location.host}/ws`);
+        socket.binaryType = 'arraybuffer';
+        socket.onopen = () => resolve();
+        socket.onerror = () => reject(new Error('无法连接本地拨号服务'));
+        socket.onclose = () => {
+            connectionBadge.className = 'badge offline';
+            connectionBadge.innerHTML = '<i></i>已断开';
+            callActive = false;
+        };
+        socket.onmessage = (event) => {
+            if (event.data instanceof ArrayBuffer) playPcm(event.data);
+            else handleServerMessage(JSON.parse(String(event.data)) as ServerMessage);
+        };
+    });
+}
+
+function handleServerMessage(message: ServerMessage): void {
+    if (message.type === 'error') {
+        showError(message.message ?? '未知错误');
+        connectButton.disabled = false;
+        connectButton.textContent = '重试连接';
+        return;
+    }
+    if (message.type === 'pbx-state' && message.state === 'connected') {
+        ($('#appSecret') as HTMLInputElement).value = '';
+        connectionBadge.className = 'badge online';
+        connectionBadge.innerHTML = '<i></i>已连接';
+        setupPanel.classList.add('hidden');
+        phonePanel.classList.remove('hidden');
+        return;
+    }
+    if (message.type !== 'call-state') return;
+    if (message.state === 'dialing') beginCall(message.party ?? numberInput.value, 'outgoing', false);
+    else if (message.state === 'connected') beginCall(message.party ?? '未知号码', message.direction ?? 'incoming', true);
+    else if (message.state === 'ended' || message.state === 'idle') endCall();
+}
+
+function beginCall(party: string, direction: 'incoming' | 'outgoing', answered: boolean): void {
+    if (!currentHistory) {
+        currentHistory = {
+            id: crypto.randomUUID(),
+            party,
+            direction,
+            startedAt: Date.now(),
+            answered,
+        };
+    } else if (answered) currentHistory.answered = true;
+
+    numberInput.value = party;
+    numberInput.readOnly = true;
+    callLabel.textContent = direction === 'incoming' ? 'INCOMING CALL' : answered ? 'CONNECTED' : 'CALLING';
+    callTimer.textContent = answered ? '00:00' : '正在呼叫…';
+    callButton.classList.add('hidden');
+    backspaceButton.classList.add('hidden');
+    hangupButton.classList.remove('hidden');
+    callActive = answered;
+    if (answered) {
+        callStartedAt = Date.now();
+        playbackTime = audioContext?.currentTime ?? 0;
+        if (timerId) window.clearInterval(timerId);
+        timerId = window.setInterval(updateTimer, 1000);
+    }
+}
+
+function updateTimer(): void {
+    const elapsed = Math.floor((Date.now() - callStartedAt) / 1000);
+    callTimer.textContent = `${String(Math.floor(elapsed / 60)).padStart(2, '0')}:${String(elapsed % 60).padStart(2, '0')}`;
+}
+
+function endCall(): void {
+    if (timerId) window.clearInterval(timerId);
+    timerId = null;
+    callActive = false;
+    playbackTime = 0;
+    if (currentHistory) {
+        currentHistory.endedAt = Date.now();
+        saveHistory(currentHistory);
+        currentHistory = null;
+    }
+    callLabel.textContent = 'READY TO CALL';
+    callTimer.textContent = '等待拨号';
+    numberInput.value = '';
+    numberInput.readOnly = false;
+    callButton.classList.remove('hidden');
+    backspaceButton.classList.remove('hidden');
+    hangupButton.classList.add('hidden');
+}
+
+function getHistory(): HistoryEntry[] {
+    try { return JSON.parse(localStorage.getItem('3cx-web-dialer-history') ?? '[]') as HistoryEntry[]; }
+    catch { return []; }
+}
+
+function saveHistory(entry: HistoryEntry): void {
+    localStorage.setItem('3cx-web-dialer-history', JSON.stringify([entry, ...getHistory()].slice(0, 50)));
+    renderHistory();
+}
+
+function renderHistory(): void {
+    const entries = getHistory();
+    if (!entries.length) {
+        historyList.innerHTML = '<div class="history-empty">还没有通话记录</div>';
+        return;
+    }
+    historyList.replaceChildren(...entries.map((entry) => {
+        const row = document.createElement('div');
+        row.className = 'history-item';
+        const duration = entry.answered && entry.endedAt ? Math.max(0, Math.floor((entry.endedAt - entry.startedAt) / 1000)) : 0;
+        row.innerHTML = `<div class="history-icon ${entry.answered ? '' : 'missed'}">${entry.direction === 'incoming' ? '↙' : '↗'}</div><div><div class="history-party"></div><div class="history-meta">${entry.direction === 'incoming' ? '呼入' : '呼出'} · ${entry.answered ? `${duration} 秒` : '未接通'}</div></div><div class="history-time">${new Date(entry.startedAt).toLocaleString('zh-CN', { month: 'numeric', day: 'numeric', hour: '2-digit', minute: '2-digit' })}</div>`;
+        row.querySelector('.history-party')!.textContent = entry.party;
+        row.addEventListener('click', () => { if (!callActive) numberInput.value = entry.party; });
+        return row;
+    }));
+}
+
+connectForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    connectButton.disabled = true;
+    connectButton.textContent = '正在连接…';
+    try {
+        await prepareAudio();
+        await connectSocket();
+        send({
+            type: 'connect',
+            pbxBase: ($('#pbxBase') as HTMLInputElement).value,
+            appId: ($('#appId') as HTMLInputElement).value,
+            appSecret: ($('#appSecret') as HTMLInputElement).value,
+        });
+    } catch (error) {
+        connectButton.disabled = false;
+        connectButton.textContent = '重试连接';
+        showError(error instanceof Error ? error.message : String(error));
+    }
+});
+
+$('#keypad').addEventListener('click', (event) => {
+    const button = (event.target as HTMLElement).closest<HTMLButtonElement>('button[data-key]');
+    if (!button || numberInput.readOnly) return;
+    const key = button.dataset.key ?? '';
+    if (key === '0' && numberInput.value === '0') numberInput.value = '+';
+    else numberInput.value += key;
+});
+
+backspaceButton.addEventListener('click', () => { numberInput.value = numberInput.value.slice(0, -1); });
+callButton.addEventListener('click', async () => {
+    const destination = numberInput.value.trim();
+    if (!destination) return showError('请先输入号码');
+    try {
+        await prepareAudio();
+        send({ type: 'dial', destination });
+    } catch (error) { showError(error instanceof Error ? error.message : String(error)); }
+});
+hangupButton.addEventListener('click', () => send({ type: 'hangup' }));
+muteButton.addEventListener('click', () => {
+    muted = !muted;
+    muteButton.classList.toggle('active', muted);
+    muteButton.textContent = muted ? '静' : '♩';
+});
+$('#clearHistoryButton').addEventListener('click', () => {
+    localStorage.removeItem('3cx-web-dialer-history');
+    renderHistory();
+});
+numberInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') callButton.click();
+});
+
+renderHistory();

--- a/examples/web-dialer/web/app.ts
+++ b/examples/web-dialer/web/app.ts
@@ -1,6 +1,6 @@
 interface ServerMessage {
     type: 'pbx-state' | 'call-state' | 'error';
-    state?: 'connected' | 'disconnected' | 'dialing' | 'connected' | 'ended' | 'idle';
+    state?: 'connected' | 'disconnected' | 'dialing' | 'ringing' | 'ended' | 'idle';
     message?: string;
     party?: string;
     direction?: 'incoming' | 'outgoing';
@@ -22,10 +22,15 @@ const connectionBadge = $('#connectionBadge');
 const connectForm = $('#connectForm') as HTMLFormElement;
 const connectButton = $('#connectButton') as HTMLButtonElement;
 const numberInput = $('#numberInput') as HTMLInputElement;
+const keypad = $('#keypad');
 const callButton = $('#callButton') as HTMLButtonElement;
+const callActions = $('#callActions');
 const hangupButton = $('#hangupButton') as HTMLButtonElement;
 const backspaceButton = $('#backspaceButton') as HTMLButtonElement;
 const muteButton = $('#muteButton') as HTMLButtonElement;
+const incomingActions = $('#incomingActions');
+const acceptButton = $('#acceptButton') as HTMLButtonElement;
+const rejectButton = $('#rejectButton') as HTMLButtonElement;
 const callLabel = $('#callLabel');
 const callTimer = $('#callTimer');
 const historyList = $('#historyList');
@@ -40,7 +45,13 @@ let callActive = false;
 let callStartedAt = 0;
 let timerId: number | null = null;
 let playbackTime = 0;
+let ringtoneTimer: number | null = null;
+const playbackSources = new Set<AudioBufferSourceNode>();
+const ringtoneOscillators = new Set<OscillatorNode>();
 let currentHistory: HistoryEntry | null = null;
+
+const maxSocketBufferedBytes = 64 * 1024;
+const maxPlaybackBacklogSeconds = 0.25;
 
 function showError(message: string): void {
     toast.textContent = message;
@@ -64,7 +75,7 @@ async function prepareAudio(): Promise<void> {
     });
     audioContext = new AudioContext();
     const source = audioContext.createMediaStreamSource(mediaStream);
-    micProcessor = audioContext.createScriptProcessor(4096, 1, 1);
+    micProcessor = audioContext.createScriptProcessor(1024, 1, 1);
     const silentGain = audioContext.createGain();
     silentGain.gain.value = 0;
     source.connect(micProcessor);
@@ -72,7 +83,13 @@ async function prepareAudio(): Promise<void> {
     silentGain.connect(audioContext.destination);
 
     micProcessor.onaudioprocess = (event) => {
-        if (!callActive || muted || socket?.readyState !== WebSocket.OPEN || !audioContext) return;
+        if (
+            !callActive
+            || muted
+            || socket?.readyState !== WebSocket.OPEN
+            || socket.bufferedAmount >= maxSocketBufferedBytes
+            || !audioContext
+        ) return;
         const input = event.inputBuffer.getChannelData(0);
         socket.send(floatToPcm16(downsample(input, audioContext.sampleRate, 8000)));
     };
@@ -114,9 +131,54 @@ function playPcm(data: ArrayBuffer): void {
     source.buffer = buffer;
     source.connect(audioContext.destination);
     const now = audioContext.currentTime;
-    playbackTime = Math.max(playbackTime, now + 0.04);
+    if (playbackTime - now > maxPlaybackBacklogSeconds) stopPlayback();
+    playbackTime = Math.max(playbackTime, now + 0.025);
+    playbackSources.add(source);
+    source.onended = () => playbackSources.delete(source);
     source.start(playbackTime);
     playbackTime += buffer.duration;
+}
+
+function stopPlayback(): void {
+    for (const source of playbackSources) {
+        try { source.stop(); } catch { /* already stopped */ }
+    }
+    playbackSources.clear();
+    playbackTime = 0;
+}
+
+function ringOnce(): void {
+    if (!audioContext) return;
+    const gain = audioContext.createGain();
+    gain.gain.setValueAtTime(0.0001, audioContext.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.08, audioContext.currentTime + 0.02);
+    gain.gain.setValueAtTime(0.08, audioContext.currentTime + 0.8);
+    gain.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + 0.95);
+    gain.connect(audioContext.destination);
+    for (const frequency of [440, 480]) {
+        const oscillator = audioContext.createOscillator();
+        oscillator.frequency.value = frequency;
+        oscillator.connect(gain);
+        ringtoneOscillators.add(oscillator);
+        oscillator.onended = () => ringtoneOscillators.delete(oscillator);
+        oscillator.start();
+        oscillator.stop(audioContext.currentTime + 1);
+    }
+}
+
+function startRingtone(): void {
+    stopRingtone();
+    ringOnce();
+    ringtoneTimer = window.setInterval(ringOnce, 3000);
+}
+
+function stopRingtone(): void {
+    if (ringtoneTimer) window.clearInterval(ringtoneTimer);
+    ringtoneTimer = null;
+    for (const oscillator of ringtoneOscillators) {
+        try { oscillator.stop(); } catch { /* already stopped */ }
+    }
+    ringtoneOscillators.clear();
 }
 
 function connectSocket(): Promise<void> {
@@ -130,6 +192,8 @@ function connectSocket(): Promise<void> {
             connectionBadge.className = 'badge offline';
             connectionBadge.innerHTML = '<i></i>已断开';
             callActive = false;
+            stopRingtone();
+            stopPlayback();
         };
         socket.onmessage = (event) => {
             if (event.data instanceof ArrayBuffer) playPcm(event.data);
@@ -155,6 +219,7 @@ function handleServerMessage(message: ServerMessage): void {
     }
     if (message.type !== 'call-state') return;
     if (message.state === 'dialing') beginCall(message.party ?? numberInput.value, 'outgoing', false);
+    else if (message.state === 'ringing') beginIncomingRing(message.party ?? '未知号码');
     else if (message.state === 'connected') beginCall(message.party ?? '未知号码', message.direction ?? 'incoming', true);
     else if (message.state === 'ended' || message.state === 'idle') endCall();
 }
@@ -176,14 +241,40 @@ function beginCall(party: string, direction: 'incoming' | 'outgoing', answered: 
     callTimer.textContent = answered ? '00:00' : '正在呼叫…';
     callButton.classList.add('hidden');
     backspaceButton.classList.add('hidden');
+    keypad.classList.remove('hidden');
+    callActions.classList.remove('hidden');
+    incomingActions.classList.add('hidden');
     hangupButton.classList.remove('hidden');
     callActive = answered;
     if (answered) {
+        stopRingtone();
         callStartedAt = Date.now();
         playbackTime = audioContext?.currentTime ?? 0;
         if (timerId) window.clearInterval(timerId);
         timerId = window.setInterval(updateTimer, 1000);
     }
+}
+
+function beginIncomingRing(party: string): void {
+    currentHistory = {
+        id: crypto.randomUUID(),
+        party,
+        direction: 'incoming',
+        startedAt: Date.now(),
+        answered: false,
+    };
+    numberInput.value = party;
+    numberInput.readOnly = true;
+    callLabel.textContent = 'INCOMING CALL';
+    callTimer.textContent = '来电响铃中…';
+    callButton.classList.add('hidden');
+    backspaceButton.classList.add('hidden');
+    keypad.classList.add('hidden');
+    callActions.classList.add('hidden');
+    hangupButton.classList.add('hidden');
+    incomingActions.classList.remove('hidden');
+    callActive = false;
+    startRingtone();
 }
 
 function updateTimer(): void {
@@ -195,7 +286,8 @@ function endCall(): void {
     if (timerId) window.clearInterval(timerId);
     timerId = null;
     callActive = false;
-    playbackTime = 0;
+    stopRingtone();
+    stopPlayback();
     if (currentHistory) {
         currentHistory.endedAt = Date.now();
         saveHistory(currentHistory);
@@ -205,8 +297,11 @@ function endCall(): void {
     callTimer.textContent = '等待拨号';
     numberInput.value = '';
     numberInput.readOnly = false;
+    keypad.classList.remove('hidden');
+    callActions.classList.remove('hidden');
     callButton.classList.remove('hidden');
     backspaceButton.classList.remove('hidden');
+    incomingActions.classList.add('hidden');
     hangupButton.classList.add('hidden');
 }
 
@@ -274,7 +369,18 @@ callButton.addEventListener('click', async () => {
         send({ type: 'dial', destination });
     } catch (error) { showError(error instanceof Error ? error.message : String(error)); }
 });
-hangupButton.addEventListener('click', () => send({ type: 'hangup' }));
+hangupButton.addEventListener('click', () => {
+    endCall();
+    send({ type: 'hangup' });
+});
+acceptButton.addEventListener('click', () => {
+    stopRingtone();
+    send({ type: 'accept' });
+});
+rejectButton.addEventListener('click', () => {
+    endCall();
+    send({ type: 'hangup' });
+});
 muteButton.addEventListener('click', () => {
     muted = !muted;
     muteButton.classList.toggle('active', muted);

--- a/examples/web-dialer/web/index.html
+++ b/examples/web-dialer/web/index.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <meta name="description" content="基于 3CX Call Control API 的免 SIP 注册网页拨号盘示例" />
+    <title>3CX Web Dialer</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <main class="shell">
+      <header class="hero">
+        <div class="brand-mark" aria-hidden="true">3</div>
+        <div>
+          <p class="eyebrow">CALL CONTROL LAB</p>
+          <h1>Web Dialer</h1>
+        </div>
+        <span id="connectionBadge" class="badge offline"><i></i>未连接</span>
+      </header>
+
+      <section id="setupPanel" class="card setup-card">
+        <div class="section-heading">
+          <div>
+            <p class="eyebrow">PRIVATE SESSION</p>
+            <h2>连接你的 3CX</h2>
+          </div>
+          <span class="lock">凭据仅保存在本机服务内存</span>
+        </div>
+        <form id="connectForm">
+          <label>3CX 域名<input id="pbxBase" type="url" required placeholder="https://company.3cx.com" autocomplete="url" /></label>
+          <div class="field-row">
+            <label>Client ID<input id="appId" required placeholder="webdialer" autocomplete="username" /></label>
+            <label>Key<input id="appSecret" type="password" required placeholder="••••••••••••" autocomplete="current-password" /></label>
+          </div>
+          <button id="connectButton" class="primary wide" type="submit">连接并启用音频</button>
+        </form>
+      </section>
+
+      <section id="phonePanel" class="phone-grid hidden">
+        <article class="card dialer-card">
+          <div class="call-display">
+            <p id="callLabel" class="eyebrow">READY TO CALL</p>
+            <input id="numberInput" aria-label="电话号码" inputmode="tel" placeholder="输入号码" autocomplete="off" />
+            <p id="callTimer" class="call-timer">等待拨号</p>
+          </div>
+
+          <div id="keypad" class="keypad" aria-label="拨号盘">
+            <button data-key="1"><b>1</b><span>&nbsp;</span></button>
+            <button data-key="2"><b>2</b><span>ABC</span></button>
+            <button data-key="3"><b>3</b><span>DEF</span></button>
+            <button data-key="4"><b>4</b><span>GHI</span></button>
+            <button data-key="5"><b>5</b><span>JKL</span></button>
+            <button data-key="6"><b>6</b><span>MNO</span></button>
+            <button data-key="7"><b>7</b><span>PQRS</span></button>
+            <button data-key="8"><b>8</b><span>TUV</span></button>
+            <button data-key="9"><b>9</b><span>WXYZ</span></button>
+            <button data-key="*"><b>*</b><span>&nbsp;</span></button>
+            <button data-key="0"><b>0</b><span>+</span></button>
+            <button data-key="#"><b>#</b><span>&nbsp;</span></button>
+          </div>
+
+          <div class="call-actions">
+            <button id="backspaceButton" class="round secondary" aria-label="删除一位">⌫</button>
+            <button id="callButton" class="round call" aria-label="拨号">☎</button>
+            <button id="muteButton" class="round secondary" aria-label="静音">♩</button>
+          </div>
+          <button id="hangupButton" class="hangup hidden" type="button">结束通话</button>
+        </article>
+
+        <aside class="card history-card">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">RECENTS</p>
+              <h2>通话记录</h2>
+            </div>
+            <button id="clearHistoryButton" class="text-button">清空</button>
+          </div>
+          <div id="historyList" class="history-list"></div>
+        </aside>
+      </section>
+
+      <p id="toast" class="toast hidden" role="status"></p>
+    </main>
+    <script type="module" src="/app.js"></script>
+  </body>
+</html>

--- a/examples/web-dialer/web/index.html
+++ b/examples/web-dialer/web/index.html
@@ -60,10 +60,14 @@
             <button data-key="#"><b>#</b><span>&nbsp;</span></button>
           </div>
 
-          <div class="call-actions">
+          <div id="callActions" class="call-actions">
             <button id="backspaceButton" class="round secondary" aria-label="删除一位">⌫</button>
             <button id="callButton" class="round call" aria-label="拨号">☎</button>
             <button id="muteButton" class="round secondary" aria-label="静音">♩</button>
+          </div>
+          <div id="incomingActions" class="incoming-actions hidden">
+            <button id="rejectButton" class="round reject" type="button" aria-label="拒接">✕</button>
+            <button id="acceptButton" class="round accept" type="button" aria-label="接听">☎</button>
           </div>
           <button id="hangupButton" class="hangup hidden" type="button">结束通话</button>
         </article>

--- a/examples/web-dialer/web/style.css
+++ b/examples/web-dialer/web/style.css
@@ -1,0 +1,73 @@
+:root {
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #f7f9f8;
+  background: #07110e;
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; min-height: 100vh; background: radial-gradient(circle at 15% 10%, #16392d 0, transparent 35%), radial-gradient(circle at 85% 85%, #13293b 0, transparent 38%), #07110e; }
+button, input { font: inherit; }
+button { color: inherit; }
+.hidden { display: none !important; }
+.shell { width: min(1040px, calc(100% - 32px)); margin: 0 auto; padding: 38px 0 64px; }
+.hero { display: flex; align-items: center; gap: 14px; margin-bottom: 26px; }
+.brand-mark { display: grid; place-items: center; width: 48px; height: 48px; border-radius: 15px; color: #04110c; background: #6ef0ae; font-size: 28px; font-weight: 900; box-shadow: 0 0 30px #54efa54d; }
+.hero h1, .section-heading h2 { margin: 0; font-weight: 650; letter-spacing: -0.03em; }
+.hero h1 { font-size: 25px; }
+.eyebrow { margin: 0 0 4px; color: #85aa9a; font-size: 10px; font-weight: 800; letter-spacing: .18em; }
+.badge { margin-left: auto; display: flex; align-items: center; gap: 8px; padding: 9px 13px; border: 1px solid #ffffff15; border-radius: 999px; background: #ffffff08; color: #a7b7b0; font-size: 12px; }
+.badge i { width: 7px; height: 7px; border-radius: 50%; background: #718078; }
+.badge.online { color: #8cf6bb; border-color: #6ef0ae35; background: #6ef0ae0e; }
+.badge.online i { background: #6ef0ae; box-shadow: 0 0 10px #6ef0ae; }
+.card { border: 1px solid #ffffff12; border-radius: 26px; background: linear-gradient(145deg, #12221dcf, #0b1714e8); box-shadow: 0 25px 70px #00000045; backdrop-filter: blur(20px); }
+.setup-card { max-width: 720px; margin: 60px auto 0; padding: 34px; }
+.section-heading { display: flex; align-items: center; justify-content: space-between; gap: 20px; margin-bottom: 24px; }
+.section-heading h2 { font-size: 20px; }
+.lock { color: #789388; font-size: 11px; }
+form { display: grid; gap: 18px; }
+label { display: grid; gap: 8px; color: #a4b7ae; font-size: 12px; }
+.field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+input { width: 100%; border: 1px solid #ffffff17; border-radius: 13px; outline: none; background: #050c0a99; color: #f7f9f8; padding: 14px 15px; transition: border-color .2s, box-shadow .2s; }
+input:focus { border-color: #6ef0ae8f; box-shadow: 0 0 0 3px #6ef0ae16; }
+.primary { border: 0; border-radius: 14px; background: #6ef0ae; color: #062116; font-weight: 800; cursor: pointer; padding: 14px 18px; }
+.primary:disabled { opacity: .55; cursor: wait; }
+.wide { width: 100%; }
+.phone-grid { display: grid; grid-template-columns: minmax(340px, 1fr) minmax(300px, .85fr); gap: 22px; align-items: start; }
+.dialer-card, .history-card { padding: 28px; }
+.call-display { padding: 12px 8px 20px; text-align: center; }
+.call-display input { border: 0; padding: 5px; background: transparent; text-align: center; font-size: clamp(28px, 5vw, 42px); font-weight: 550; letter-spacing: .03em; box-shadow: none; }
+.call-display input::placeholder { color: #53655e; }
+.call-timer { height: 18px; margin: 8px 0 0; color: #799088; font-size: 12px; }
+.keypad { display: grid; grid-template-columns: repeat(3, 74px); justify-content: center; gap: 13px 24px; padding: 12px 0 20px; }
+.keypad button { display: grid; place-items: center; width: 74px; height: 66px; border: 1px solid #ffffff10; border-radius: 22px; background: #ffffff08; cursor: pointer; transition: transform .12s, background .12s; }
+.keypad button:hover { background: #ffffff12; }
+.keypad button:active { transform: scale(.94); }
+.keypad b { font-size: 24px; font-weight: 500; line-height: 22px; }
+.keypad span { color: #73877e; font-size: 8px; font-weight: 800; letter-spacing: .15em; }
+.call-actions { display: grid; grid-template-columns: repeat(3, 64px); justify-content: center; align-items: center; gap: 26px; margin-top: 12px; }
+.round { width: 58px; height: 58px; border: 0; border-radius: 50%; cursor: pointer; font-size: 20px; }
+.round.secondary { background: #ffffff0d; color: #b7c6bf; }
+.round.call { width: 64px; height: 64px; background: #55e99c; color: #062116; font-size: 25px; box-shadow: 0 12px 35px #55e99c42; }
+.round.active { background: #ffd383; color: #352100; }
+.hangup { width: 100%; margin-top: 20px; padding: 14px; border: 0; border-radius: 14px; background: #ff65751c; color: #ff8793; cursor: pointer; font-weight: 750; }
+.text-button { border: 0; background: none; color: #74cfa2; cursor: pointer; font-size: 12px; }
+.history-list { display: grid; gap: 4px; }
+.history-empty { padding: 70px 10px; color: #60736a; text-align: center; font-size: 13px; }
+.history-item { display: grid; grid-template-columns: 38px 1fr auto; gap: 12px; align-items: center; padding: 13px 8px; border-bottom: 1px solid #ffffff0c; }
+.history-icon { display: grid; place-items: center; width: 38px; height: 38px; border-radius: 12px; background: #ffffff09; color: #72e5a6; }
+.history-icon.missed { color: #ff8994; }
+.history-party { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 14px; font-weight: 650; }
+.history-meta, .history-time { margin-top: 3px; color: #6f847a; font-size: 10px; }
+.history-time { text-align: right; }
+.toast { position: fixed; left: 50%; bottom: 28px; transform: translateX(-50%); max-width: calc(100% - 32px); margin: 0; padding: 12px 16px; border: 1px solid #ff87934a; border-radius: 12px; background: #2d1216ee; color: #ffabb3; font-size: 12px; box-shadow: 0 12px 40px #0008; }
+
+@media (max-width: 760px) {
+  .shell { width: min(100% - 20px, 520px); padding-top: 20px; }
+  .phone-grid { grid-template-columns: 1fr; }
+  .setup-card, .dialer-card, .history-card { padding: 22px; border-radius: 22px; }
+  .field-row { grid-template-columns: 1fr; }
+  .lock { display: none; }
+  .keypad { grid-template-columns: repeat(3, 68px); gap: 11px 20px; }
+  .keypad button { width: 68px; height: 62px; }
+}

--- a/examples/web-dialer/web/style.css
+++ b/examples/web-dialer/web/style.css
@@ -50,6 +50,10 @@ input:focus { border-color: #6ef0ae8f; box-shadow: 0 0 0 3px #6ef0ae16; }
 .round.secondary { background: #ffffff0d; color: #b7c6bf; }
 .round.call { width: 64px; height: 64px; background: #55e99c; color: #062116; font-size: 25px; box-shadow: 0 12px 35px #55e99c42; }
 .round.active { background: #ffd383; color: #352100; }
+.incoming-actions { display: flex; justify-content: center; gap: 72px; margin-top: 12px; }
+.round.accept, .round.reject { width: 66px; height: 66px; font-size: 24px; }
+.round.accept { background: #55e99c; color: #062116; box-shadow: 0 12px 35px #55e99c42; }
+.round.reject { background: #ff6575; color: white; box-shadow: 0 12px 35px #ff657530; }
 .hangup { width: 100%; margin-top: 20px; padding: 14px; border: 0; border-radius: 14px; background: #ff65751c; color: #ff8793; cursor: pointer; font-weight: 750; }
 .text-button { border: 0; background: none; color: #74cfa2; cursor: pointer; font-size: 12px; }
 .history-list { display: grid; gap: 4px; }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "start:alibaba-qwen": "yarn workspace @3cx-examples/alibaba-qwen-realtime start",
     "start:xai": "yarn workspace @3cx-examples/xai-realtime start",
     "start:gemini": "yarn workspace @3cx-examples/gemini-realtime start",
-    "start": "echo '' && echo 'Please specify an example to start:' && echo '' && echo '  yarn start:openai            # OpenAI Realtime API' && echo '  yarn start:alibaba-qwen      # Alibaba Qwen Omni Realtime' && echo '  yarn start:xai               # xAI Grok Voice Agent' && echo '  yarn start:gemini            # Gemini Live API' && echo '' && exit 1"
+    "start:web-dialer": "yarn workspace @3cx-examples/web-dialer start",
+    "start": "echo '' && echo 'Please specify an example to start:' && echo '' && echo '  yarn start:openai            # OpenAI Realtime API' && echo '  yarn start:alibaba-qwen      # Alibaba Qwen Omni Realtime' && echo '  yarn start:xai               # xAI Grok Voice Agent' && echo '  yarn start:gemini            # Gemini Live API' && echo '  yarn start:web-dialer        # Browser dialer (no SIP registration)' && echo '' && exit 1"
   },
   "packageManager": "yarn@4.16.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,6 +109,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@3cx-examples/web-dialer@workspace:examples/web-dialer":
+  version: 0.0.0-use.local
+  resolution: "@3cx-examples/web-dialer@workspace:examples/web-dialer"
+  dependencies:
+    "@3cx/call-control-sdk": "npm:^0.1.10"
+    "@types/node": "npm:^24.0.0"
+    "@types/ws": "npm:^8.18.1"
+    tsx: "npm:^4.21.0"
+    typescript: "npm:^5.9.3"
+    ws: "npm:^8.20.0"
+  languageName: unknown
+  linkType: soft
+
 "@3cx-examples/xai-realtime@workspace:examples/xai-realtime":
   version: 0.0.0-use.local
   resolution: "@3cx-examples/xai-realtime@workspace:examples/xai-realtime"


### PR DESCRIPTION
## What changed

- add a standalone TypeScript browser dialer under `examples/web-dialer`
- connect to a 3CX programmable DN with PBX URL, Client ID, and Key
- bridge browser microphone and speaker audio through 3CX 8 kHz PCM streams
- support outbound dialing, inbound RoutePoint calls, mute, hangup, timer, and local recent-call history
- add a virtual incoming-call ringing phase with accept/reject controls and ringback for the caller
- bound browser, WebSocket, and PBX audio queues to prevent latency growth
- synchronously clear microphone, PBX writer, ringtone, and speaker queues on hangup
- keep 3CX credentials in the local Node session without browser persistence
- add root workspace and README entry points

## Why

This provides a minimal reference for building a browser calling client with the Call Control API without registering a SIP endpoint.

RoutePoint calls are already connected by the PBX, so the ringing phase is intentionally virtual: media is withheld until the browser user accepts the call.

## Validation

- `yarn workspace @3cx-examples/web-dialer build`
- `yarn build`
- local HTTP and WebSocket protocol smoke tests
- real-browser rendering and accessibility snapshot

## Notes

No live PBX credentials were available, so the final 3CX inbound/outbound media path still needs validation against a configured RoutePoint. The sample intentionally binds to localhost and documents the additional controls required before remote or production deployment.
